### PR TITLE
README.md: fixes output formatting in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ for (name, value) in form_data.fields {
 }
 
 for (name, file) in form_data.files {
-    println!("Posted file name={} filename={} content_type={} size={} temporary_path={}",
+    println!("Posted file name={} filename={:?} content_type={} size={} temporary_path={:?}",
              name, file.filename, file.content_type, file.size, file.path);
 }
 


### PR DESCRIPTION
Thanks for open sourcing this library :+1: looks very interesting !

The strings from the README won't compile at the moment. This little commit fixes that for me on Rust 1.2.0.

Best regards,
Conrad
