### PR TITLE
Update to hyper 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 keywords = ["multipart", "form-data", "hyper", "http", "mime"]
 
 [dependencies]
-hyper = "^0.6"
+hyper = "^0.7"
 httparse = "^1.0"
 mime = "^0.1"
 tempdir = "^0.3"

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -25,6 +25,7 @@
 use std::fmt;
 use std::io::{self, Read, Write, Cursor};
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use hyper::net::NetworkStream;
 
@@ -83,5 +84,13 @@ impl Write for MockStream {
 impl NetworkStream for MockStream {
     fn peer_addr(&mut self) -> io::Result<SocketAddr> {
         Ok("127.0.0.1:1337".parse().unwrap())
+    }
+
+    fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        Ok(())
     }
 }


### PR DESCRIPTION
Trying to use this crate (or crates that depend on it) in junction with hyper 0.7 cause a native linking error with openssl-sys. This resolves it by updating to hyper 0.7, and implementing the two other required methods for the NetworkStream trait introduced in 0.7

The error:

```
native library `openssl` is being linked to by more than one version of the same package, but it can only be linked once; try updating or pinning your dependencies to ensure that this package only shows up once

  openssl-sys v0.7.1
  openssl-sys v0.6.7
```
