### PR TITLE
Make ssl a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ keywords = ["multipart", "form-data", "hyper", "http", "mime"]
 build = "build.rs"
 
 [features]
-default = ["with-syntex"]
+default = ["with-syntex", "ssl"]
 with-syntex = ["syntex", "serde_codegen"]
+ssl = ["hyper/ssl"]
 
 [build-dependencies]
 serde_codegen = { version = "^0.6", optional = true }
@@ -25,7 +26,7 @@ syntex = { version = "^0", optional = true }
 serde_json = "^0.6"
 
 [dependencies]
-hyper = "^0.7"
+hyper = {version = "^0.7", default-features = false } 
 httparse = "^1.0"
 mime = "^0.1"
 tempdir = "^0.3"


### PR DESCRIPTION
Disable default features of hyper and add a new ssl feature to enable the "hyper/ssl" feature. Add the new ssl feature to default. This makes it possible to disable the usage of openssl.
