### PR TITLE
Update syntex and hyper versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ syntex = { version = "0.31", optional = true }
 serde_json = "0.7"
 
 [dependencies]
-hyper = {version = "0.8", default-features = false }
+hyper = {version = "0.9", default-features = false }
 httparse = "1.1"
 mime = { version = "0.2", features = [ "serde" ] }
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ with-syntex = [ "rust-stable" ]
 
 [build-dependencies]
 serde_codegen = { version = "0.7", optional = true }
-syntex = { version = "0.30", optional = true }
+syntex = { version = "0.31", optional = true }
 
 [dev-dependencies]
 serde_json = "0.7"


### PR DESCRIPTION
Other dependencies (ex: aster, quasi, etc) have updated to syntex 0.31, which causes errors like this when I try to build formdata:

```
build.rs:15:33: 15:46 error: mismatched types:
 expected `&mut syntex::Registry`,
    found `&mut inner::syntex::Registry`
(expected struct `syntex::Registry`,
    found struct `inner::syntex::Registry`) [E0308]
build.rs:15         serde_codegen::register(&mut registry);
                                            ^~~~~~~~~~~~~
```

Updating the dependency to syntex 0.31 to match the other dependencies fixes the issue for me.
