### PR TITLE
Update deprecated idioms and dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ tempdir = "0.3"
 hyper = { version = "0.10" }
 httparse = "1.2"
 mime = "0.2"
-textnonce = "0.6"
+textnonce = "0.8"
 log = "0.4"
 encoding = "0.2"
 clippy = { version = "0.0", optional = true }
-mime_multipart = "0.5"
+mime_multipart = "0.6"

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,27 +79,27 @@ impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Httparse(ref e) =>
-                format!("{}: {:?}", self.description(), e).fmt(f),
+                format!("{}: {:?}", self, e).fmt(f),
             Error::Io(ref e) =>
-                format!("{}: {}", self.description(), e).fmt(f),
+                format!("{}: {}", self, e).fmt(f),
             Error::Hyper(ref e) =>
-                format!("{}: {}", self.description(), e).fmt(f),
+                format!("{}: {}", self, e).fmt(f),
             Error::Utf8(ref e) =>
-                format!("{}: {}", self.description(), e).fmt(f),
+                format!("{}: {}", self, e).fmt(f),
             Error::Decoding(ref e) =>
-                format!("{}: {}", self.description(), e).fmt(f),
+                format!("{}: {}", self, e).fmt(f),
             Error::Multipart(ref e) =>
-                format!("{}: {}", self.description(), e).fmt(f),
-            _ => format!("{}", self.description()).fmt(f),
+                format!("{}: {}", self, e).fmt(f),
+            _ => format!("{}", self).fmt(f),
         }
     }
 }
 
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!( f.write_str(&*self.description()) );
+        write!(f, "{}", self)?;
         if self.source().is_some() {
-            try!( write!(f, ": {:?}", self.source().unwrap()) ); // recurse
+            write!(f, ": {:?}", self.source().unwrap())?; // recurse
         }
         Ok(())
     }


### PR DESCRIPTION
This is the final round of bumps I'm attempting to do to update dependencies of an old codebase of mine :)

Continuation for: https://github.com/mikedilger/textnonce/pull/21 and https://github.com/mikedilger/mime-multipart/pull/11

Not sure about the version bump for this crate... The minimum supported Rust version was raised for the dependencies, so maybe a 0.x bump would be warranted...